### PR TITLE
fix: remove breaking parameters 

### DIFF
--- a/internal/vault/autounseal.go
+++ b/internal/vault/autounseal.go
@@ -71,10 +71,8 @@ func (conf *VaultConfiguration) UnsealRaftLeader(clientset *kubernetes.Clientset
 		log.Infof("initializing vault raft leader")
 
 		initResponse, err := vaultClient.Sys().Init(&vaultapi.InitRequest{
-			RecoveryShares:    RecoveryShares,
-			RecoveryThreshold: RecoveryThreshold,
-			SecretShares:      SecretShares,
-			SecretThreshold:   SecretThreshold,
+			SecretShares:    SecretShares,
+			SecretThreshold: SecretThreshold,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description
removed parameters recovery_shares,recovery_thr no longer supported for vault upgrade 1.17.2

## How to test
Build the Docker image, create a Kubernetes Job that waits for vault-0 to initialize, and then run the Job against the Vault engine.
